### PR TITLE
Normalize the response from storage.get()

### DIFF
--- a/srv/main.js
+++ b/srv/main.js
@@ -112,6 +112,8 @@ sauropod.get('/app/:appid/users/:userid/keys/:key', function(req, res) {
     } else {
         storage.get(verify["user"], verify["bucket"], key, function(err, data) {
             if (!err) {
+                data.user = verify["user"];
+                data.bucket = verify["bucket"];
                 res.send(JSON.stringify(data), 200);
             } else {
                 res.send("Error " + err, 500);

--- a/srv/sandbox/sandbox.js
+++ b/srv/sandbox/sandbox.js
@@ -102,7 +102,7 @@ function doReq(type, key, val, cb) {
 function doGet() {
 	doReq("GET", document.getElementById("getKey").value, null, function(data) {
 		var val = JSON.parse(data);
-		document.getElementById("getValue").value = val[0]['$'];
+		document.getElementById("getValue").value = val.value;
 	});
 }
 

--- a/srv/storage.js
+++ b/srv/storage.js
@@ -41,7 +41,15 @@ function put(user, audience, key, value, cb) {
 function get(user, audience, key, cb) {
     var row = db.getRow(hash(audience), hash(user));
     row.get("key:" + key, function(err, success) {
-        cb(err, success); 
+        var data = {};
+        if (err) {
+            cb(err, success); 
+        } else {
+            data.key = key;
+            data.value = success[0].$;
+            data.timestamp = success[0].timestamp;
+            cb(err, data); 
+        }
     });
 }
 


### PR DESCRIPTION
This patch translates the hbase-specific object retrieved by the
storage backend into something more generic, so we don't expose
details of the underlying storage in the client API.
