### PR TITLE
Add a /__heartbeat__ page.

### DIFF
--- a/srv/main.js
+++ b/srv/main.js
@@ -198,5 +198,15 @@ sauropod.get('/app/:appid/users/:userid/keys/:key', function(req, res) {
     }
 });
 
+sauropod.get('/__heartbeat__', function(req, res) {
+    storage.ping(function(err) {
+        if(!err) {
+            res.send("OK", 200);
+        } else {
+            res.send("ERROR: storage is not accessible", 500);
+        }
+    });
+});
+
 logger.info('Serving on http://localhost:8001');
 sauropod.listen(8001);

--- a/srv/storage.js
+++ b/srv/storage.js
@@ -90,5 +90,12 @@ function get(user, audience, key, cb) {
     });
 }
 
+function ping(cb) {
+    db.getVersion(function(err, version) {
+        cb(err);
+    });
+}
+
 exports.put = put;
 exports.get = get;
+exports.ping = ping;


### PR DESCRIPTION
Accessing this page does a simple ping of hbase, returning "200 OK"
is all is well and "500 Server Error" if hbase is down.

This seems to need the latest node-hbase trunk to work reliably; older versions of node-hbase just die if they can't connect to the hbase rest interface.
