### PR TITLE
Handle mocking of new-format BrowserID assertions.

### DIFF
--- a/srv/main.js
+++ b/srv/main.js
@@ -101,9 +101,16 @@ function dummyVerifyBrowserID(assertion, audience, cb) {
         return payload;
     }
     try {
-        var bundle = JSON.parse(base64urldecode(assertion));
-        var cert = bundle["certificates"][bundle["certificates"].length - 1];
-        var assert = bundle["assertion"];
+        if(assertion.indexOf("~") != -1) {
+            var bundle = assertion.split("~");
+            var cert = bundle[bundle.length - 2];
+            var assert = bundle[bundle.length - 1];
+        } else {
+            var bundle = JSON.parse(base64urldecode(assertion));
+            var certs = bundle["certificates"];
+            var cert = certs[certs.length - 1];
+            var assert = bundle["assertion"];
+        }
         if (parseJWT(assert)["aud"] != audience) {
             cb({'error': 'Invalid user'});
         } else {

--- a/srv/sandbox/sandbox.js
+++ b/srv/sandbox/sandbox.js
@@ -56,9 +56,15 @@ function extractUser(assertion) {
     return window.atob(s); // Standard base64 decoder
   }
 
-  var assert = JSON.parse(base64urldecode(assertion));
-  var jwt = assert["certificates"][0];
-  var data = jwt.split(".");
+  if(assertion.indexOf("~") != -1) {
+      var bundle = assertion.split("~");
+      var cert = bundle[bundle.length - 2];
+  } else {
+      var bundle = JSON.parse(base64urldecode(assertion));
+      var certs = bundle["certificates"];
+      var cert = certs[certs.length - 1];
+  }
+  var data = cert.split(".");
   var payload = JSON.parse(base64urldecode(data[1]));
   return payload["principal"]["email"];
 }


### PR DESCRIPTION
The BrowserID assertion format has changed, so our mocking routines are now broken.  This patch should fix it, although my local hbase install seems to be fubared so I haven't tested it yet...
